### PR TITLE
[INFRA] add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.md
+++ b/.github/ISSUE_TEMPLATE/blank.md
@@ -1,0 +1,7 @@
+---
+name: Blank issue
+about: Create an issue without a template.
+title: ''
+labels: ''
+assignees: ''
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug report
+
+# See the json schema to help you create / update this form
+# https://json.schemastore.org/github-issue-forms.json
+
+description: Fill in this template to report a bug
+
+title: "[BUG] "
+
+labels: ["bug"]
+
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description:
+        Please search to see if an issue already exists for the bug you
+        encountered.
+      options:
+        - label: I have searched the existing issues
+
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: Describe what outcome you expected.
+      placeholder: Describe what outcome you expected.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: Describe what you got instead.
+      placeholder: Describe what you got instead.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Error message
+      description: If possible paste below the error message you encountered.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Environment
+      description: |
+        If necessary give information about your setup.
+      value: |
+        - OS:
+        - Python version:
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Version
+      description: |
+        Which version did you encounter this bug on?
+      value: |
+        - version:
+
+  - type: textarea
+    attributes:
+      label: How to reproduce
+      description: |
+        What is the command you ran? 
+
+        Ideally provide a minimal example that reproduces the bug.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+
+# See the json schema to help you create / update this form
+# https://json.schemastore.org/github-issue-forms.json
+
+description: Suggest an idea for this project
+
+title: "[ENH] "
+
+labels: ["enhancement"]
+
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description:
+        Please search to see if an issue already exists for the feature you
+        want.
+      options:
+        - label: I have searched the existing issues
+
+  - type: textarea
+    attributes:
+      label: New feature
+      description: You think / need this to do...
+      placeholder: Insert here your cool idea.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Unclear documentation
+      description: |
+        Something is missing / unclear about **X**.
+
+        You are confused about how to do **Y**.
+
+        It is not clear how / why the code does **Z**.
+
+        That means that we can improve the code or the documentation.
+      placeholder: Tell us more.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+<!---
+This is a suggested pull request template.
+It's designed to capture information we've found to be useful in reviewing pull requests.
+
+If there is other information that would be helpful to include, please don't hesitate to add it!
+-->
+
+<!-- Please indicate after the # which issue you're closing with this PR.
+This is helpful for the maintainers AND will magically close the issue
+when this pull request is merged!
+If the PR closes multiple issues, includes "closes" before each one is listed.
+
+You can also just link to other issues if necessary, e.g. "See also #1234".
+
+https://help.github.com/articles/closing-issues-using-keywords
+-->
+Closes # 
+See also #
+
+<!-- Please give a brief overview of what has changed in the PR.
+If you're not sure what to write, consider it a note to the maintainers
+to indicate what they should be looking for when they review the pull request.
+-->
+Changes proposed in this pull request:
+
+-
+-


### PR DESCRIPTION
Relates to https://github.com/neurobagel/project/issues/37

This PR would add issue and PR templates to the whole organization.

- Issue templates uses the github issue forms
- For PR templates I used something closes to the things that exist in nilearn

I suspect but have not checked that a template in a repo of the same orga with same name would override the default set in the `.github`  of that same orga.

I will merge this in the main branch of my fork so you can play around and see what the templates look like when actually used (feel free to open dummy issues and PR on my fork to try things out)

https://github.com/Remi-Gau/neurobagel_dot_github/issues/new/choose